### PR TITLE
Replaced tab with new line for stat output

### DIFF
--- a/weeSAMv1.4
+++ b/weeSAMv1.4
@@ -189,7 +189,7 @@ sub makeSumStats{
       print OUT sprintf("%.2f",(($info{$id}{"cov0.5"}/$info{$id}{"reflength"}) * 100))."\t";
       print OUT sprintf("%.2f",(($info{$id}{"cov1.0"}/$info{$id}{"reflength"}) * 100))."\t";
       print OUT sprintf("%.2f",(($info{$id}{"cov1.8"}/$info{$id}{"reflength"}) * 100))."\t";
-      print OUT sprintf("%.2f",($info{$id}{"coefVar"}))."\t";
+      print OUT sprintf("%.2f",($info{$id}{"coefVar"}))."\n";
     }
   }
 }


### PR DESCRIPTION
Replaced \t with \n in stat out in order to split several alignment hits.
Very useful if you want to compare the assembly hits vs alignment of reference fasta files.